### PR TITLE
Add Liveblocks to docs 

### DIFF
--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -87,11 +87,17 @@ As a reference, our [tldraw-yjs example](https://github.com/tldraw/tldraw-yjs-ex
 
 Whichever backend you choose, adding collaboration to tldraw will involve synchronizing data, sharing user presence, and handling user assets.
 
-### Synchronizing data
+### Third party back ends
+
+- **[Liveblocks](https://liveblocks.io/multiplayer-editing)**: Hosted tldraw with DevTools, webhooks, REST API, Node.js library. Get started with [Storage](https://liveblocks.io/examples/tldraw-whiteboard) and [Yjs](https://liveblocks.io/examples/tldraw-whiteboard/nextjs-tldraw-whiteboard-yjs) examples.
+
+### Manual setup
+
+#### Synchronizing data
 
 For more information about how to synchronize the tldraw editor's store with other processes (i.e. how to get data out and put data in, including from remote sources) see the [Persistence](/docs/persistence) page.
 
-### User presence
+#### User presence
 
 The tldraw SDK has support for displaying the 'presence' of other users. Presence information consists of the user id, name, and color, as well as their canvas context, such as their current page, pointer position, selection, viewport.
 
@@ -103,7 +109,7 @@ To the editor, any `instance_presence` records that belong to other users (i.e. 
 
 See the [yjs-example](https://github.com/tldraw/tldraw-yjs-example/blob/45dfe7589ae44e4aaf9bb7359d0372f3a88bd597/src/useYjsStore.ts) for an example of how these records may be created, shared, and updated.
 
-### Collaboration UI
+#### Collaboration UI
 
 The `tldraw` library includes several components specifically designed for collaboration.
 You can remove, replace, or customize these using the editor's `components` prop. See [TLComponents](?) for more info.


### PR DESCRIPTION
Adds a new section for third-party backends on the Collaboration page, and mentions Liveblocks.